### PR TITLE
DD-1451 - Prevent putting empty s3 files on

### DIFF
--- a/bots/kinesis_processor/index.js
+++ b/bots/kinesis_processor/index.js
@@ -95,7 +95,12 @@ exports.handler = function(event, context, callback) {
 				}
 				delete obj.stats;
 				delete obj.correlations;
-				done(null, obj);
+				
+				if (obj.records) { 
+					done(null, obj);
+				} else {
+					done();
+				}
 			});
 			if (useS3Mode) {
 				events[event] = ls.pipeline(ls.toS3GzipChunks(event, {}), assignIds, ls.toDynamoDB(StreamTable));


### PR DESCRIPTION
We need to prevent putting empty s3 files on the bus.  leo-sdk has a fix to prevent it, but this is an additional measure to stop them at kinesis processor.