### PR TITLE
Handle when we get string event_source_timestamp

### DIFF
--- a/bots/kinesis_processor/index.js
+++ b/bots/kinesis_processor/index.js
@@ -253,8 +253,7 @@ exports.handler = function(event, context, callback) {
 			event.event_source_timestamp = event.timestamp;
 		}
 		if (typeof event.event_source_timestamp !== "number"){
-		    console.log("Fixing non number event_source_timestamp", JSON.stringify(event, null, 2))
-		    event.event_source_timestamp = moment(event.event_source_timestamp).valueOf()
+		    event.event_source_timestamp = moment(event.event_source_timestamp).valueOf();
 		}
 		getEventStream(event.event, forceEventId, archive).write(event, callback);
 	}), function(err) {

--- a/bots/kinesis_processor/index.js
+++ b/bots/kinesis_processor/index.js
@@ -252,6 +252,10 @@ exports.handler = function(event, context, callback) {
 		if (!event.event_source_timestamp) {
 			event.event_source_timestamp = event.timestamp;
 		}
+		if (typeof event.event_source_timestamp !== "number"){
+		    console.log("Fixing non number event_source_timestamp", JSON.stringify(event, null, 2))
+		    event.event_source_timestamp = moment(event.event_source_timestamp).valueOf()
+		}
 		getEventStream(event.event, forceEventId, archive).write(event, callback);
 	}), function(err) {
 		if (err) {


### PR DESCRIPTION
Sometimes, clients put on an event with a source_timestamp that is a string instead of unix timestamp, so this converts it for them.